### PR TITLE
gImageGameObject class has been added.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PLUGIN_LIBS_DIR ${PLUGIN_DIR}/libs)
 ##### PLUGIN SOURCES #####
 list(APPEND PLUGIN_SRCS
 			${PLUGIN_DIR}/src/gipBulletPhysics.cpp
+			${PLUGIN_DIR}/src/gImageGameObject.cpp
 )
 
 

--- a/src/gImageGameObject.cpp
+++ b/src/gImageGameObject.cpp
@@ -1,0 +1,25 @@
+/*
+ * gImageGameObject.cpp
+ *
+ *  Created on: 24 Aðu 2022
+ *      Author: Faruk Aygun
+ */
+
+#include <gImageGameObject.h>
+
+gImageGameObject::gImageGameObject(gImage image, float positionx, float positiony, float rotationx, float rotationy) {
+	this->image = image;
+	this->positionx = positionx;
+	this->positiony = positiony;
+	this->rotationx = rotationx;
+	this->rotationy = rotationy;
+}
+
+gImageGameObject::~gImageGameObject() {
+	// TODO Auto-generated destructor stub
+}
+
+void gImageGameObject::draw() {
+
+}
+

--- a/src/gImageGameObject.h
+++ b/src/gImageGameObject.h
@@ -1,0 +1,30 @@
+/*
+ * gImageGameObject.h
+ *
+ *  Created on: 24 Aðu 2022
+ *      Author: Faruk
+ */
+
+#ifndef SRC_GIMAGEGAMEOBJECT_H_
+#define SRC_GIMAGEGAMEOBJECT_H_
+
+#include "gImage.h"
+
+#include "glm/glm.hpp"
+
+class gImageGameObject {
+public:
+	gImageGameObject(gImage image, float positionx, float positiony, float rotationx, float rotationy);
+	virtual ~gImageGameObject();
+
+	void draw();
+
+	gImage image;
+
+	float positionx;
+	float positiony;
+	float rotationx;
+	float rotationy;
+};
+
+#endif /* SRC_GIMAGEGAMEOBJECT_H_ */

--- a/src/gipBulletPhysics.cpp
+++ b/src/gipBulletPhysics.cpp
@@ -19,129 +19,134 @@ void gipBulletPhysics::update() {
 }
 
 void gipBulletPhysics::initialize() {
-	collisionConfiguration = new btDefaultCollisionConfiguration();
-	dispatcher = new btCollisionDispatcher(collisionConfiguration);
-	overlappingPairCache = new btDbvtBroadphase();
+	collisionconfiguration = new btDefaultCollisionConfiguration();
+	dispatcher = new btCollisionDispatcher(collisionconfiguration);
+	overlappingpaircache = new btDbvtBroadphase();
 	solver = new btSequentialImpulseConstraintSolver ;
-	dynamicsWorld = new btDiscreteDynamicsWorld (dispatcher, overlappingPairCache, solver, collisionConfiguration);
+	dynamicsworld = new btDiscreteDynamicsWorld (dispatcher, overlappingpaircache, solver, collisionconfiguration);
 }
 
-void gipBulletPhysics::setGravity(float gravityValue) {
-	dynamicsWorld->setGravity(btVector3 (0, gravityValue, 0));
+void gipBulletPhysics::setGravity(float gravityvalue) {
+	dynamicsworld->setGravity(btVector3 (0, gravityvalue, 0));
 }
 
 void gipBulletPhysics::addRigidBody(btRigidBody* rb) {
-	dynamicsWorld->addRigidBody(rb);
+	dynamicsworld->addRigidBody(rb);
 }
 
-void gipBulletPhysics::create2dBoxObject(gImage img, float x, float y, float objMass) {
-	btTransform box2dTransform;
+void gipBulletPhysics::create2dBoxObject(gImageGameObject* imgobject, float objmass) {
+	btTransform box2dtransform;
 
-	btCollisionShape* box2dShape = new btBoxShape(btVector3(img.getWidth(), img.getHeight(), 1.0f));
-	collisionShapes.push_back(box2dShape);
+	btCollisionShape* box2dshape = new btBoxShape(btVector3(imgobject->image.getWidth(), imgobject->image.getHeight(), 1.0f));
+	collisionshapes.push_back(box2dshape);
 
-	box2dTransform.setIdentity();
+	box2dtransform.setIdentity();
 	/*
 	 * The Glist Engine references the top left corner for object positions;
 	 * but the bullet3 library references the bottom left for object positions.
 	 * so we should convert Glist positions to bullet3 positions with (+img.getHeight()).
 	 */
-	box2dTransform.setOrigin(btVector3(x, -(y + img.getHeight()), 0));
-	btScalar mass(objMass);
+	box2dtransform.setOrigin(btVector3(imgobject->positionx, -(imgobject->positiony + imgobject->image.getHeight()), 0));
+	btScalar mass(objmass);
 
 	//rigidbody is dynamic if and only if mass is non zero, otherwise static
 	bool isDynamic = (mass != 0.f);
 
 	btVector3 localInertia(0, 0, 0);
 	if (isDynamic)
-		box2dShape->calculateLocalInertia(mass, localInertia);
+		box2dshape->calculateLocalInertia(mass, localInertia);
 
 	//using motionstate is optional, it provides interpolation capabilities, and only synchronizes 'active' objects
-	btDefaultMotionState* myMotionState = new btDefaultMotionState(box2dTransform);
-	btRigidBody::btRigidBodyConstructionInfo box2dRbInfo(mass, myMotionState, box2dShape, localInertia);
-	btRigidBody* box2dRigidBody = new btRigidBody(box2dRbInfo);
+	btDefaultMotionState* mymotionstate = new btDefaultMotionState(box2dtransform);
+	btRigidBody::btRigidBodyConstructionInfo box2drbinfo(mass, mymotionstate, box2dshape, localInertia);
+	btRigidBody* box2drigidbody = new btRigidBody(box2drbinfo);
 
-	addRigidBody(box2dRigidBody);
+	addRigidBody(box2drigidbody);
 
 	// gLogi("box") << float(box2dTransform.getOrigin().getX()) << " " << float(box2dTransform.getOrigin().getY());
 }
 
-void gipBulletPhysics::create2dCircleObject(gImage img, float x, float y, float objMass) {
-	btTransform circle2dTransform;
+void gipBulletPhysics::create2dCircleObject(gImageGameObject* imgobject, float objmass) {
+	btTransform circle2dtransform;
 
 	// parameter is circle radius
-	btCollisionShape* circle2dShape = new btSphereShape(img.getWidth() / 2);
-	collisionShapes.push_back(circle2dShape);
+	btCollisionShape* circle2dshape = new btSphereShape(imgobject->image.getWidth() / 2);
+	collisionshapes.push_back(circle2dshape);
 
-	circle2dTransform.setIdentity();
+	circle2dtransform.setIdentity();
 	/*
 	 * The Glist Engine references the top left corner for object positions;
 	 * but the bullet3 library references the center for circle object positions.
 	 * so we should convert Glist positions to bullet3 positions with (+img.getWidth() / 2 and +img.getHeight() / 2).
 	 */
-	circle2dTransform.setOrigin(btVector3(x + (img.getWidth() / 2), -(y + img.getHeight() / 2), 0));
+	circle2dtransform.setOrigin(
+			btVector3(imgobject->positionx + (imgobject->image.getWidth() / 2),
+			-(imgobject->positiony + imgobject->image.getHeight() / 2), 0)
+	);
 
-	btScalar mass(objMass);
+	btScalar mass(objmass);
 
 	//rigidbody is dynamic if and only if mass is non zero, otherwise static
-	bool isDynamic = (mass != 0.f);
+	bool isdynamic = (mass != 0.f);
 
 	btVector3 localInertia(0, 0, 0);
-	if (isDynamic)
-		circle2dShape->calculateLocalInertia(mass, localInertia);
+	if (isdynamic)
+		circle2dshape->calculateLocalInertia(mass, localInertia);
 
 	//using motionstate is optional, it provides interpolation capabilities, and only synchronizes 'active' objects
-	btDefaultMotionState* myMotionState = new btDefaultMotionState(circle2dTransform);
-	btRigidBody::btRigidBodyConstructionInfo circle2dRbInfo(mass, myMotionState, circle2dShape, localInertia);
-	btRigidBody* circle2dRigidBody = new btRigidBody(circle2dRbInfo);
+	btDefaultMotionState* mymotionstate = new btDefaultMotionState(circle2dtransform);
+	btRigidBody::btRigidBodyConstructionInfo circle2drbinfo(mass, mymotionstate, circle2dshape, localInertia);
+	btRigidBody* circle2drigidbody = new btRigidBody(circle2drbinfo);
 
-	addRigidBody(circle2dRigidBody);
+	addRigidBody(circle2drigidbody);
 
 	// gLogi("circle") << float(circle2dTransform.getOrigin().getX()) << " " << float(circle2dTransform.getOrigin().getY());
 }
 
-int gipBulletPhysics::stepSimulation(btScalar timeStep, int maxSubSteps , btScalar fixedTimeStep) {
-	return dynamicsWorld->stepSimulation(timeStep, maxSubSteps, fixedTimeStep);
+int gipBulletPhysics::stepSimulation(btScalar timestep, int maxsubsteps , btScalar fixedtimestep) {
+	return dynamicsworld->stepSimulation(timestep, maxsubsteps, fixedtimestep);
 }
 
 int gipBulletPhysics::getNumCollisionObjects() {
-	return dynamicsWorld->getNumCollisionObjects();
+	return dynamicsworld->getNumCollisionObjects();
 }
 
 btCollisionObjectArray& gipBulletPhysics::getCollisionObjectArray() {
-	return dynamicsWorld->getCollisionObjectArray();
+	return dynamicsworld->getCollisionObjectArray();
 }
 
-btVector3& gipBulletPhysics::getOrigin(btTransform* trans) {
-	return trans->getOrigin();
+glm::vec2 gipBulletPhysics::getOrigin2d(btTransform* trans) {
+	btVector3& position = trans->getOrigin();
+	return glm::vec2 (
+			position.getX(),
+			position.getY()
+	);
 }
 
 // convert bullet3 positions to Glist Engine positions and return for circle objects.
-btVector3 gipBulletPhysics::getCircle2dObjectPosition(btTransform trans, float imgWidth, float imgHeight) {
+glm::vec2 gipBulletPhysics::getCircle2dObjectPosition(btTransform transform, float imgwidth, float imgheight) {
 	// gLogi("circle (x,y)") << trans.getOrigin().getX() - (imgWidth / 2) << " " << -(trans.getOrigin().getY() + imgHeight / 2);
-	return btVector3(
-			trans.getOrigin().getX() - (imgWidth / 2),
-			-(trans.getOrigin().getY() + imgHeight / 2),
-			0.0f
+	return glm::vec2 (
+			transform.getOrigin().getX() - (imgwidth / 2),
+			-(transform.getOrigin().getY() + imgheight / 2)
 	);
 }
 
 // convert bullet3 positions to Glist Engine positions and return for box objects.
-btVector3 gipBulletPhysics::getBox2dObjectPosition(btTransform trans, float imgWidth, float imgHeight) {
+glm::vec2 gipBulletPhysics::getBox2dObjectPosition(btTransform trans, float imgwidth, float imgheight) {
 	// gLogi("box (x,y)") << trans.getOrigin().getX() << " " << -(trans.getOrigin().getY() + imgHeight);
-	return btVector3(
+	return glm::vec2 (
 			trans.getOrigin().getX(),
-			-(trans.getOrigin().getY() + imgHeight),
-			0.0f
+			-(trans.getOrigin().getY() + imgheight)
 	);
 }
 
 void gipBulletPhysics::clean() {
-	delete collisionConfiguration;
+	delete collisionconfiguration;
 	delete dispatcher;
-	delete overlappingPairCache;
+	delete overlappingpaircache;
 	delete solver;
-	delete dynamicsWorld;
+	delete dynamicsworld;
 }
 
 

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -25,20 +25,20 @@ public:
 	void initialize();
 	// Delete initialized objects
 	void clean();
-	void setGravity(float gravityValue);
+	void setGravity(float gravityvalue);
 	void addRigidBody(btRigidBody* rb);
-	void create2dBoxObject(gImageGameObject* imgobject, float objMass);
-	void create2dCircleObject(gImageGameObject* imgobject, float objMass);
+	void create2dBoxObject(gImageGameObject* imgobject, float objmass);
+	void create2dCircleObject(gImageGameObject* imgobject, float objmass);
 
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
-	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
+	int  stepSimulation(btScalar timestep, int maxsubsteps = 1, btScalar fixedtimestep = btScalar(1.) / btScalar(60.));
 	int  getNumCollisionObjects();
 
 	// Return the origin vector translation
-	glm::vec2 getOrigin2d(btTransform* trans);
+	glm::vec2 getOrigin2d(btTransform* transform);
 	// Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
-	glm::vec2 getCircle2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
-	glm::vec2 getBox2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
+	glm::vec2 getCircle2dObjectPosition(btTransform transform, float imgwidth, float imgheight);
+	glm::vec2 getBox2dObjectPosition(btTransform transform, float imgwidth, float imgheight);
 
 	btCollisionObjectArray& getCollisionObjectArray();
 

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -10,10 +10,10 @@
 #define SRC_GIPBULLETPHYSICS_H_
 
 #include "gBasePlugin.h"
+#include "gImageGameObject.h"
 
 #include "bullet/btBulletDynamicsCommon.h"
-
-#include <stdio.h>
+#include "glm/glm.hpp"
 
 class gipBulletPhysics : public gBasePlugin{
 public:
@@ -27,30 +27,31 @@ public:
 	void clean();
 	void setGravity(float gravityValue);
 	void addRigidBody(btRigidBody* rb);
-	void create2dBoxObject(gImage img, float x, float y, float objMass);
-	void create2dCircleObject(gImage img, float x, float y, float objMass);
+	void create2dBoxObject(gImageGameObject* imgobject, float objMass);
+	void create2dCircleObject(gImageGameObject* imgobject, float objMass);
 
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
 	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
 	int  getNumCollisionObjects();
 
 	// Return the origin vector translation
-	btVector3& getOrigin(btTransform* trans);
+	glm::vec2 getOrigin2d(btTransform* trans);
 	// Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
-	btVector3 getCircle2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
-	btVector3 getBox2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
+	glm::vec2 getCircle2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
+	glm::vec2 getBox2dObjectPosition(btTransform trans, float imgWidth, float imgHeight);
+
 	btCollisionObjectArray& getCollisionObjectArray();
 
 	// keep track of the shapes, we release memory at exit.
 	// make sure to re-use collision shapes among rigid bodies whenever possible!
-	btAlignedObjectArray<btCollisionShape*> collisionShapes;
+	btAlignedObjectArray<btCollisionShape*> collisionshapes;
 
 private:
-	btDefaultCollisionConfiguration* collisionConfiguration;
+	btDefaultCollisionConfiguration* collisionconfiguration;
 	btCollisionDispatcher* dispatcher;
-	btBroadphaseInterface* overlappingPairCache;
+	btBroadphaseInterface* overlappingpaircache;
 	btSequentialImpulseConstraintSolver* solver;
-	btDiscreteDynamicsWorld* dynamicsWorld;
+	btDiscreteDynamicsWorld* dynamicsworld;
 };
 
 #endif /* SRC_GIPBULLETPHYSICS_H_ */


### PR DESCRIPTION
gImageGameObject class has been added.

- Bullet3 compatible type methods have been converted to Glist Engine compatible type.
- Changed to glm::vec2 instead of btVector3.
- gImageGameObject class store gImage, image position and rotation.
- getCircle2dObjectPositionn and getBox2dObjectPosition methods allow gImageGameObject pointer type parameter instead of gImage, float, float parameters.
- Naming convention changed to flattype instead of camelCase.