### PR TITLE
Methods parameters changed.

### DIFF
--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -3,7 +3,7 @@
  *
  *  Created on: 5 Aug 2022
  *      Author: Faruk Aygun,
- *      		Emirhan Limon
+ *      		Emirhan Limon<
  */
 
 #ifndef SRC_GIPBULLETPHYSICS_H_
@@ -13,6 +13,7 @@
 #include "gImageGameObject.h"
 
 #include "bullet/btBulletDynamicsCommon.h"
+
 #include "glm/glm.hpp"
 
 class gipBulletPhysics : public gBasePlugin{
@@ -22,31 +23,35 @@ public:
 
 	void update();
 
+	// initialize worlds
 	void initialize();
+
 	// Delete initialized objects
 	void clean();
-	void setGravity(float gravityvalue);
-	void addRigidBody(btRigidBody* rb);
-	void create2dBoxObject(gImageGameObject* imgobject, float objmass);
-	void create2dCircleObject(gImageGameObject* imgobject, float objmass);
+	void setGravity(float gravityValue);
+	void createBox2dObject(gImageGameObject* imgObject, float objMass);
+	void createCircle2dObject(gImageGameObject* imgObject, float objMass);
 
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
-	int  stepSimulation(btScalar timestep, int maxsubsteps = 1, btScalar fixedtimestep = btScalar(1.) / btScalar(60.));
+	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
 	int  getNumCollisionObjects();
 
 	// Return the origin vector translation
-	glm::vec2 getOrigin2d(btTransform* transform);
+	glm::vec2 getOrigin2d(int gameObjectNo);
 	// Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
-	glm::vec2 getCircle2dObjectPosition(btTransform transform, float imgwidth, float imgheight);
-	glm::vec2 getBox2dObjectPosition(btTransform transform, float imgwidth, float imgheight);
+	// convert bullet3 positions to Glist Engine positions and return for circle objects.
+	glm::vec2 getCircle2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject);
+	// convert bullet3 positions to Glist Engine positions and return for box objects.
+	glm::vec2 getBox2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject);
 
 	btCollisionObjectArray& getCollisionObjectArray();
 
 	// keep track of the shapes, we release memory at exit.
 	// make sure to re-use collision shapes among rigid bodies whenever possible!
 	btAlignedObjectArray<btCollisionShape*> collisionshapes;
-
 private:
+	void createRigidBody(btRigidBody* rigidBody);
+
 	btDefaultCollisionConfiguration* collisionconfiguration;
 	btCollisionDispatcher* dispatcher;
 	btBroadphaseInterface* overlappingpaircache;


### PR DESCRIPTION
- Bullet3 compatible type methods have been converted to Glist Engine compatible type.
- Now instead of getting btTransform* with parameter, getting btTransform* object in method with (int)gameObjectNo.
- Replaced the float type width and height parameters  with gImageGameObject*.
- addRigidBody method name changed to createRigidBody.
- createRigidBody method using in plugin only, therefore changed to private access type from public.
- Method parameter's naming convention changed to camelCase instead of flattype.