### PR TITLE
Now provides bouncing physics of objects in collisions.

### DIFF
--- a/src/gImageGameObject.cpp
+++ b/src/gImageGameObject.cpp
@@ -1,7 +1,7 @@
 /*
  * gImageGameObject.cpp
  *
- *  Created on: 24 Aðu 2022
+ *  Created on: 24 Aug 2022
  *      Author: Faruk Aygun
  */
 
@@ -22,4 +22,3 @@ gImageGameObject::~gImageGameObject() {
 void gImageGameObject::draw() {
 
 }
-

--- a/src/gImageGameObject.h
+++ b/src/gImageGameObject.h
@@ -1,7 +1,7 @@
 /*
  * gImageGameObject.h
  *
- *  Created on: 24 Aðu 2022
+ *  Created on: 24 Aug 2022
  *      Author: Faruk Aygun
  */
 
@@ -18,7 +18,11 @@ public:
 	virtual ~gImageGameObject();
 
 	void draw();
+	// TODO: create method body.
+	void loadImage(std::string imageName);
 
+	// TODO: set access modifier private and create get-set methods
+	// TODO: create (float)objMass variable
 	gImage image;
 
 	int id = -1;

--- a/src/gImageGameObject.h
+++ b/src/gImageGameObject.h
@@ -2,7 +2,7 @@
  * gImageGameObject.h
  *
  *  Created on: 24 Aðu 2022
- *      Author: Faruk
+ *      Author: Faruk Aygun
  */
 
 #ifndef SRC_GIMAGEGAMEOBJECT_H_
@@ -21,6 +21,7 @@ public:
 
 	gImage image;
 
+	int id = -1;
 	float positionx;
 	float positiony;
 	float rotationx;

--- a/src/gipBulletPhysics.cpp
+++ b/src/gipBulletPhysics.cpp
@@ -18,26 +18,37 @@ gipBulletPhysics::~gipBulletPhysics() {
 void gipBulletPhysics::update() {
 }
 
-void gipBulletPhysics::initialize() {
+void gipBulletPhysics::initializeRigidWorld() {
 	collisionconfiguration = new btDefaultCollisionConfiguration();
 	dispatcher = new btCollisionDispatcher(collisionconfiguration);
 	overlappingpaircache = new btDbvtBroadphase();
-	solver = new btSequentialImpulseConstraintSolver ;
+	solver = new btSequentialImpulseConstraintSolver;
 	dynamicsworld = new btDiscreteDynamicsWorld (dispatcher, overlappingpaircache, solver, collisionconfiguration);
+}
+
+void gipBulletPhysics::initializeSoftRigidWorld() {
+	collisionconfiguration = new btDefaultCollisionConfiguration();
+	dispatcher = new btCollisionDispatcher(collisionconfiguration);
+	broadphase = new btDbvtBroadphase();
+	solver = new btSequentialImpulseConstraintSolver;
+	constraintsolver = solver;
+	dynamicsworld = new btDiscreteDynamicsWorld(dispatcher, broadphase, constraintsolver, collisionconfiguration);
+
+	dynamicsworld->getSolverInfo().m_erp2 = 0.f;
+	dynamicsworld->getSolverInfo().m_globalCfm = 0.f;
+	dynamicsworld->getSolverInfo().m_numIterations = 3;
+	dynamicsworld->getSolverInfo().m_solverMode = SOLVER_SIMD;  // | SOLVER_RANDMIZE_ORDER;
+	dynamicsworld->getSolverInfo().m_splitImpulse = false;
 }
 
 void gipBulletPhysics::setGravity(float gravityValue) {
 	dynamicsworld->setGravity(btVector3 (0, gravityValue, 0));
 }
 
-void gipBulletPhysics::createRigidBody(btRigidBody* rigidBody) {
-	dynamicsworld->addRigidBody(rigidBody);
-}
-
 int gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMass) {
 	btTransform box2dtransform;
-
 	btCollisionShape* box2dshape = new btBoxShape(btVector3(imgObject->image.getWidth(), imgObject->image.getHeight(), 1.0f));
+	// TODO: btBox2dShape* box2dshape = new btBox2dShape(btVector3(imgObject->image.getWidth(), imgObject->image.getHeight(), 0.0f));
 	collisionshapes.push_back(box2dshape);
 
 	box2dtransform.setIdentity();
@@ -46,9 +57,15 @@ int gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMa
 	 * but the bullet3 library references the bottom left for object positions.
 	 * so we should convert Glist positions to bullet3 positions with (+img.getHeight()).
 	 */
-	box2dtransform.setOrigin(btVector3(imgObject->positionx, -(imgObject->positiony + imgObject->image.getHeight()), 0));
-	btScalar mass(objMass);
+	box2dtransform.setOrigin(
+			btVector3(
+					imgObject->positionx,
+					-(imgObject->positiony + imgObject->image.getHeight()),
+					0
+			)
+	);
 
+	btScalar mass(objMass);
 	//rigidbody is dynamic if and only if mass is non zero, otherwise static
 	bool isDynamic = (mass != 0.f);
 
@@ -61,7 +78,7 @@ int gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMa
 	btRigidBody::btRigidBodyConstructionInfo box2drbinfo(mass, mymotionstate, box2dshape, localInertia);
 	btRigidBody* box2drigidbody = new btRigidBody(box2drbinfo);
 
-	createRigidBody(box2drigidbody);
+	dynamicsworld->addRigidBody(box2drigidbody);
 
 	gameobjectid.push_back(gameobjectid.size());
 	// gLogi("box") << float(box2dTransform.getOrigin().getX()) << " " << float(box2dTransform.getOrigin().getY());
@@ -71,7 +88,6 @@ int gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMa
 
 int gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float objMass) {
 	btTransform circle2dtransform;
-
 	// parameter is circle radius
 	btCollisionShape* circle2dshape = new btSphereShape(imgObject->image.getWidth() / 2);
 	collisionshapes.push_back(circle2dshape);
@@ -83,8 +99,11 @@ int gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float ob
 	 * so we should convert Glist positions to bullet3 positions with (+img.getWidth() / 2 and +img.getHeight() / 2).
 	 */
 	circle2dtransform.setOrigin(
-			btVector3(imgObject->positionx + (imgObject->image.getWidth() / 2),
-			-(imgObject->positiony + imgObject->image.getHeight() / 2), 0)
+			btVector3(
+					imgObject->positionx + (imgObject->image.getWidth() / 2),
+					-(imgObject->positiony + imgObject->image.getHeight() / 2),
+					0
+			)
 	);
 
 	btScalar mass(objMass);
@@ -101,10 +120,114 @@ int gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float ob
 	btRigidBody::btRigidBodyConstructionInfo circle2drbinfo(mass, mymotionstate, circle2dshape, localInertia);
 	btRigidBody* circle2drigidbody = new btRigidBody(circle2drbinfo);
 
-	createRigidBody(circle2drigidbody);
+	dynamicsworld->addRigidBody(circle2drigidbody);
 
 	gameobjectid.push_back(gameobjectid.size());
 	// gLogi("circle") << float(circle2dTransform.getOrigin().getX()) << " " << float(circle2dTransform.getOrigin().getY());
+
+	return gameobjectid.back();
+}
+
+// increase stiffness, reduce dumping for harder floor.
+int gipBulletPhysics::createSoftContactBox2dObject(gImageGameObject* imgObject, float objMass, float stiffness, float damping) {
+	btTransform softbox2dtransform;
+	btCollisionShape* softbox2dshape = new btBoxShape(btVector3(imgObject->image.getWidth(), imgObject->image.getHeight(), 0.0f));
+
+	collisionshapes.push_back(softbox2dshape);
+
+	softbox2dtransform.setIdentity();
+	/*
+	 * The Glist Engine references the top left corner for object positions;
+	 * but the bullet3 library references the bottom left for object positions.
+	 * so we should convert Glist positions to bullet3 positions with (+img.getHeight()).
+	 */
+	softbox2dtransform.setOrigin(
+			btVector3(
+					imgObject->positionx,
+					-(imgObject->positiony + imgObject->image.getHeight()),
+					0
+			)
+	);
+
+	btScalar mass(objMass);
+	//rigidbody is dynamic if and only if mass is non zero, otherwise static
+	bool isDynamic = (mass != 0.f);
+
+	btVector3 localInertia(0, 0, 0);
+	if (isDynamic)
+		softbox2dshape->calculateLocalInertia(mass, localInertia);
+
+	//using motionstate is optional, it provides interpolation capabilities, and only synchronizes 'active' objects
+	btDefaultMotionState* mymotionstate = new btDefaultMotionState(softbox2dtransform);
+	btRigidBody::btRigidBodyConstructionInfo softbox2drbinfo(mass, mymotionstate, softbox2dshape, localInertia);
+	btRigidBody* softbox2drigidbody = new btRigidBody(softbox2drbinfo);
+
+	dynamicsworld->addRigidBody(softbox2drigidbody);
+
+	softbox2drigidbody->setContactStiffnessAndDamping(stiffness, damping);
+
+	gameobjectid.push_back(gameobjectid.size());
+	// gLogi("soft contact box") << float(softbox2dtransform.getOrigin().getX()) << " " << float(softbox2dtransform.getOrigin().getY());
+
+	return gameobjectid.back();
+}
+
+int gipBulletPhysics::createSoftCircle2dObject(gImageGameObject* imgObject, float objMass) {
+	btCollisionShape* softball2dchildshape = new btSphereShape(imgObject->image.getWidth() / 2); // child shape
+	btCompoundShape* softball2dcolshape = new btCompoundShape(); // parent shape
+
+	softball2dcolshape->addChildShape(btTransform::getIdentity(), softball2dchildshape);
+	collisionshapes.push_back(softball2dcolshape);
+
+	btTransform softball2dTransform;
+	softball2dTransform.setIdentity();
+
+	// ballTransform.setRotation(btQuaternion(btVector3(1.0f, 1.0f, 1.0f), SIMD_PI / 10.0));
+	btScalar mass(1.0f);
+	bool isDynamic = (mass != 0.0f);
+
+	btVector3 localInertia(0, 0, 0);
+	if (isDynamic)
+		softball2dcolshape->calculateLocalInertia(mass, localInertia);
+
+	for (int k = 0; k < 1; k++)
+	{
+		for (int i = 0; i < 1; i++)
+		{
+			for (int j = 0; j < 1; j++)
+			{
+				/*
+				 * The Glist Engine references the top left corner for object positions;
+				 * but the bullet3 library references the bottom left for object positions.
+				 * so we should convert Glist positions to bullet3 positions with (+img.getHeight()).
+				 */
+				softball2dTransform.setOrigin(
+						btVector3(
+								imgObject->positionx + imgObject->image.getWidth() / 2,
+								-(imgObject->positiony + imgObject->image.getHeight() / 2),
+								0
+						)
+				);
+
+				bool isDynamic = (mass != 0.f);
+
+				btVector3 localInertia(0, 0, 0);
+				if (isDynamic)
+					softball2dcolshape->calculateLocalInertia(mass, localInertia);
+
+				//using motionstate is optional, it provides interpolation capabilities, and only synchronizes 'active' objects
+				btDefaultMotionState* mymotionstate = new btDefaultMotionState(softball2dTransform);
+				btRigidBody::btRigidBodyConstructionInfo softball2drbinfo(mass, mymotionstate, softball2dcolshape, localInertia);
+				btRigidBody* softball2drb = new btRigidBody(softball2drbinfo);
+
+				softball2drb->setUserIndex(-1);
+
+				dynamicsworld->addRigidBody(softball2drb);
+			}
+		}
+	}
+	gameobjectid.push_back(gameobjectid.size());
+	// gLogi("box") << float(softball2dTransform.getOrigin().getX()) << " " << float(softball2dTransform.getOrigin().getY());
 
 	return gameobjectid.back();
 }
@@ -130,9 +253,9 @@ glm::vec2 gipBulletPhysics::getOrigin2d(int gameObjectNo) {
 	);
 }
 
-glm::vec2 gipBulletPhysics::getCircle2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject) {
+glm::vec2 gipBulletPhysics::getCircle2dObjectPosition(gImageGameObject* imgObject) {
 	// gLogi("circle (x,y)") << trans.getOrigin().getX() - (imgWidth / 2) << " " << -(trans.getOrigin().getY() + imgHeight / 2);
-	btCollisionObject* gameobject = getCollisionObjectArray()[gameObjectNo];
+	btCollisionObject* gameobject = getCollisionObjectArray()[imgObject->id];
 	btTransform transform = gameobject->getWorldTransform();
 	return glm::vec2 (
 			transform.getOrigin().getX() - (imgObject->image.getWidth() / 2),
@@ -140,9 +263,9 @@ glm::vec2 gipBulletPhysics::getCircle2dObjectPosition(int gameObjectNo, gImageGa
 	);
 }
 
-glm::vec2 gipBulletPhysics::getBox2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject) {
+glm::vec2 gipBulletPhysics::getBox2dObjectPosition(gImageGameObject* imgObject) {
 	// gLogi("box (x,y)") << trans.getOrigin().getX() << " " << -(trans.getOrigin().getY() + imgHeight);
-	btCollisionObject* gameobject = getCollisionObjectArray()[gameObjectNo];
+	btCollisionObject* gameobject = getCollisionObjectArray()[imgObject->id];
 	btTransform transform = gameobject->getWorldTransform();
 	return glm::vec2 (
 			transform.getOrigin().getX(),
@@ -150,12 +273,45 @@ glm::vec2 gipBulletPhysics::getBox2dObjectPosition(int gameObjectNo, gImageGameO
 	);
 }
 
+//cleanup in the reverse order of creation/initialization
 void gipBulletPhysics::clean() {
-	delete collisionconfiguration;
-	delete dispatcher;
-	delete overlappingpaircache;
-	delete solver;
+	//remove the rigidbodies from the dynamics world and delete them
+	if(dynamicsworld) {
+		int i;
+		for (i = dynamicsworld->getNumConstraints() - 1; i >= 0; i--) {
+			dynamicsworld->removeConstraint(dynamicsworld->getConstraint(i));
+		}
+		for (i = dynamicsworld->getNumCollisionObjects() - 1; i >= 0; i--) {
+			btCollisionObject* obj = getCollisionObjectArray()[i];
+			btRigidBody* body = btRigidBody::upcast(obj);
+			if (body && body->getMotionState()) {
+				delete body->getMotionState();
+			}
+			dynamicsworld->removeCollisionObject(obj);
+			delete obj;
+		}
+	}
+
+	// delete collision shapes
+	for (int j = 0; j < collisionshapes.size(); j++)
+	{
+		btCollisionShape* shape = collisionshapes[j];
+		delete shape;
+	}
+	collisionshapes.clear();
+
 	delete dynamicsworld;
+	dynamicsworld = 0;
+	delete constraintsolver;
+	constraintsolver = 0;
+	delete solver;
+	solver = 0;
+	delete broadphase;
+	broadphase = 0;
+	delete overlappingpaircache;
+	overlappingpaircache = 0;
+	delete dispatcher;
+	dispatcher = 0;
+	delete collisionconfiguration;
+	collisionconfiguration = 0;
 }
-
-

--- a/src/gipBulletPhysics.cpp
+++ b/src/gipBulletPhysics.cpp
@@ -34,7 +34,7 @@ void gipBulletPhysics::createRigidBody(btRigidBody* rigidBody) {
 	dynamicsworld->addRigidBody(rigidBody);
 }
 
-void gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMass) {
+int gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objMass) {
 	btTransform box2dtransform;
 
 	btCollisionShape* box2dshape = new btBoxShape(btVector3(imgObject->image.getWidth(), imgObject->image.getHeight(), 1.0f));
@@ -63,10 +63,13 @@ void gipBulletPhysics::createBox2dObject(gImageGameObject* imgObject, float objM
 
 	createRigidBody(box2drigidbody);
 
+	gameobjectid.push_back(gameobjectid.size());
 	// gLogi("box") << float(box2dTransform.getOrigin().getX()) << " " << float(box2dTransform.getOrigin().getY());
+
+	return gameobjectid.back();
 }
 
-void gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float objMass) {
+int gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float objMass) {
 	btTransform circle2dtransform;
 
 	// parameter is circle radius
@@ -100,7 +103,10 @@ void gipBulletPhysics::createCircle2dObject(gImageGameObject* imgObject, float o
 
 	createRigidBody(circle2drigidbody);
 
+	gameobjectid.push_back(gameobjectid.size());
 	// gLogi("circle") << float(circle2dTransform.getOrigin().getX()) << " " << float(circle2dTransform.getOrigin().getY());
+
+	return gameobjectid.back();
 }
 
 int gipBulletPhysics::stepSimulation(btScalar timeStep, int maxSubSteps , btScalar fixedTimeStep) {

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -3,7 +3,7 @@
  *
  *  Created on: 5 Aug 2022
  *      Author: Faruk Aygun,
- *      		Emirhan Limon<
+ *      		Emirhan Limon
  */
 
 #ifndef SRC_GIPBULLETPHYSICS_H_
@@ -29,9 +29,10 @@ public:
 	// Delete initialized objects
 	void clean();
 	void setGravity(float gravityValue);
-	void createBox2dObject(gImageGameObject* imgObject, float objMass);
-	void createCircle2dObject(gImageGameObject* imgObject, float objMass);
 
+	// Create methods return created object id
+	int createBox2dObject(gImageGameObject* imgObject, float objMass);
+	int createCircle2dObject(gImageGameObject* imgObject, float objMass);
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
 	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
 	int  getNumCollisionObjects();
@@ -49,6 +50,8 @@ public:
 	// keep track of the shapes, we release memory at exit.
 	// make sure to re-use collision shapes among rigid bodies whenever possible!
 	btAlignedObjectArray<btCollisionShape*> collisionshapes;
+	// keep track of the created game object ids
+	std::vector<int> gameobjectid;
 private:
 	void createRigidBody(btRigidBody* rigidBody);
 

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -23,8 +23,10 @@ public:
 
 	void update();
 
-	// initialize worlds
-	void initialize();
+	// RigidWorld should be initialized if all objects have rigidbody.
+	void initializeRigidWorld();
+	// SoftRigidWorld should be initialized if some objects have softbody.
+	void initializeSoftRigidWorld();
 
 	// Delete initialized objects
 	void clean();
@@ -33,17 +35,22 @@ public:
 	// Create methods return created object id
 	int createBox2dObject(gImageGameObject* imgObject, float objMass);
 	int createCircle2dObject(gImageGameObject* imgObject, float objMass);
+	int createSoftContactBox2dObject(gImageGameObject* imgObject, float objMass, float stiffness = 300.0f, float damping = 10.0f);
+	int createSoftCircle2dObject(gImageGameObject* imgObject, float objMass);
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
 	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
 	int  getNumCollisionObjects();
 
 	// Return the origin vector translation
 	glm::vec2 getOrigin2d(int gameObjectNo);
-	// Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
+	/*
+	 * Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
+	 * These get methods works for soft objects.
+	 */
 	// convert bullet3 positions to Glist Engine positions and return for circle objects.
-	glm::vec2 getCircle2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject);
-	// convert bullet3 positions to Glist Engine positions and return for box objects.
-	glm::vec2 getBox2dObjectPosition(int gameObjectNo, gImageGameObject* imgObject);
+	glm::vec2 getCircle2dObjectPosition(gImageGameObject* imgObject);
+	// convert> a bullet3 positions to Glist Engine positions and return for box objects.
+	glm::vec2 getBox2dObjectPosition(gImageGameObject* imgObject);
 
 	btCollisionObjectArray& getCollisionObjectArray();
 
@@ -52,14 +59,17 @@ public:
 	btAlignedObjectArray<btCollisionShape*> collisionshapes;
 	// keep track of the created game object ids
 	std::vector<int> gameobjectid;
-private:
-	void createRigidBody(btRigidBody* rigidBody);
 
+private:
 	btDefaultCollisionConfiguration* collisionconfiguration;
 	btCollisionDispatcher* dispatcher;
 	btBroadphaseInterface* overlappingpaircache;
 	btSequentialImpulseConstraintSolver* solver;
 	btDiscreteDynamicsWorld* dynamicsworld;
+
+	//soft contact
+	btConstraintSolver* constraintsolver;
+	btBroadphaseInterface* broadphase;
 };
 
 #endif /* SRC_GIPBULLETPHYSICS_H_ */


### PR DESCRIPTION
Now provides bouncing physics of objects in collisions.

- createSoftCircle2dObject and createSoftContactBox2dObject methods added.
- initializeSoftRigidWorld method added.
- gameObjectNo parameter deleted from getCircle2dObjectPosition and getBox2dObjectPosition methods.
- initialize method renamed to initializeRigidWorld.
- createRigidBody was deleted because it was not needed.
- softRigidWorld should be initialized if some objects have softbody.
- rigidWorld should be initialized if all objects have rigidbody.
- clean method has been extended.

- Create methods now return gameobject's id of type int.
- Added id of type int variable to gImageGameObject. Gameobject id is now stored in gImageGamObject.
- Added gameobjectid of type int which stores created gameobject ids.