### PR TITLE
Object rotation added.

### DIFF
--- a/src/gImageGameObject.cpp
+++ b/src/gImageGameObject.cpp
@@ -7,11 +7,13 @@
 
 #include <gImageGameObject.h>
 
-gImageGameObject::gImageGameObject(gImage image, float mass, glm::vec2 position, glm::vec2 rotation) {
+gImageGameObject::gImageGameObject(gImage image, float mass, glm::vec2 position, float rotationAngle) {
 	this->image = image;
 	this->mass = mass;
 	this->position = position;
-	this->rotation = rotation;
+	this->rotationAngle = rotationAngle;
+	width = image.getWidth();
+	height = image.getHeight();
 }
 
 gImageGameObject::~gImageGameObject() {
@@ -23,11 +25,15 @@ void gImageGameObject::draw() {
 }
 
 void gImageGameObject::loadImage(std::string imagePath) {
-	this->image.loadImage(imagePath);
+	image.loadImage(imagePath);
+	width = image.getWidth();
+	height = image.getHeight();
 }
 
 void gImageGameObject::setImage(gImage image) {
 	this->image = image;
+	width = image.getWidth();
+	height = image.getHeight();
 }
 
 void gImageGameObject::setId(int id) {
@@ -42,34 +48,35 @@ void gImageGameObject::setPosition(glm::vec2 position) {
 	this->position = position;
 }
 
-void gImageGameObject::setRotation(glm::vec2 rotation) {
-	this->rotation = rotation;
+void gImageGameObject::setRotationAngle(float rotationAngle) {
+	this->rotationAngle = rotationAngle;
 }
 
-gImage gImageGameObject::getImage() {
-	return this->image;
+
+gImage* gImageGameObject::getImage() {
+	return &image;
 }
 
 int gImageGameObject::getId() {
-	return this->id;
+	return id;
 }
 
 float gImageGameObject::getMass() {
-	return this->mass;
+	return mass;
 }
 
 float gImageGameObject::getWidth() {
-	return this->image.getWidth();
+	return width;
 }
 
 float gImageGameObject::getHeight() {
-	return this->image.getHeight();
+	return height;
+}
+
+float gImageGameObject::getRotationAngle() {
+	return rotationAngle;
 }
 
 glm::vec2 gImageGameObject::getPosition() {
-	return this->position;
-}
-
-glm::vec2 gImageGameObject::getRotation() {
-	return this->rotation;
+	return position;
 }

--- a/src/gImageGameObject.h
+++ b/src/gImageGameObject.h
@@ -9,12 +9,11 @@
 #define SRC_GIMAGEGAMEOBJECT_H_
 
 #include "gImage.h"
-
 #include "glm/glm.hpp"
 
 class gImageGameObject {
 public:
-	gImageGameObject(gImage image, float mass, glm::vec2 position, glm::vec2 rotation);
+	gImageGameObject(gImage image, float mass, glm::vec2 position, float rotationAngle);
 	virtual ~gImageGameObject();
 
 	void draw();
@@ -23,33 +22,30 @@ public:
 	void setId(int id);
 	void setMass(float mass);
 	void setPosition(glm::vec2 position);
-	void setRotation(glm::vec2 rotation);
+	void setRotationAngle(float angle);
 
-	gImage getImage();
+	gImage* getImage();
 
 	int getId();
 
 	float getMass();
-	/*
-	 * If you use image.getWidth() or getHeight() instead of these methods,
-	 * you will get <terminated> (exit value: -1.073.740.940)
-	 * see FIXME on createSoftContactBox2dObject method in gipBulletPhysics.cpp.
-	 */
 	float getWidth();
 	float getHeight();
+	float getRotationAngle();
 
 	glm::vec2 getPosition();
-	glm::vec2 getRotation();
 
 private:
 	gImage image;
 
 	float mass;
+	float rotationAngle;
 
 	glm::vec2 position;
-	glm::vec2 rotation;
 
 	int id = -1;
+	int width;
+	int height;
 };
 
 #endif /* SRC_GIMAGEGAMEOBJECT_H_ */

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -24,19 +24,22 @@ public:
 	// keep track of the shapes, we release memory at exit.
 	// make sure to re-use collision shapes among rigid bodies whenever possible!
 	btAlignedObjectArray<btCollisionShape*> collisionshapes;
-	// keep track of the created game object ids
-	std::vector<int> gameobjectid;
+	// keep track of the created game objects
+	std::vector<gImageGameObject*> gameobjects;
 
 	void update();
 
-	// RigidWorld should be initialized if all objects have rigidbody.
-	void initializeRigidWorld();
-	// SoftRigidWorld should be initialized if some objects have softbody.
-	void initializeSoftRigidWorld();
+	// initialize world first
+	void initializeWorld(int worldType);
 
 	// Delete initialized objects
 	void clean();
 	// for 2d set z axis 0
+	void setErp2(float value = 0.0f);
+	void setglobalCfm(float value = 0.0f);
+	void setNumIterations(int value = 3);
+	void setSolverMode(int solverMode = SOLVER_SIMD);
+	void setSplitImpulse(int splitImpulse = false);
 	void setGravity(glm::vec3 gravityValue);
 	void setFriction(gImageGameObject* imgObject, float frictionValue);
 	void setRollingFriction(gImageGameObject* imgObject, float frictionValue);
@@ -51,29 +54,39 @@ public:
 	void applyTorque(gImageGameObject* imgObject, glm::vec3 torqueValue);
 	void applyTorqueImpulse(gImageGameObject* imgObject, glm::vec3 torqueValue);
 
+	float getErp2();
+	float getglobalCfm();
+
+	int getNumIterations();
+	int getSolverMode();
+	int getSplitImpulse();
 	// Create methods return created object id
 	int createBox2dObject(gImageGameObject* imgObject);
 	int createCircle2dObject(gImageGameObject* imgObject);
+	// increase stiffness, reduce dumping for harder floor.
 	int createSoftContactBox2dObject(gImageGameObject* imgObject, float stiffness = 300.0f, float damping = 10.0f);
 	int createSoftCircle2dObject(gImageGameObject* imgObject);
 	// The btScalar type abstracts floating point numbers, to easily switch between double and single floating point precision.
-	int  stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
-	int  getNumCollisionObjects();
+	int stepSimulation(btScalar timeStep, int maxSubSteps = 1, btScalar fixedTimeStep = btScalar(1.) / btScalar(60.));
 
 	// Return the origin vector translation
-	glm::vec2 getOrigin2d(int gameObjectNo);
+	glm::vec2 getOrigin2d(int imgObjectId);
 	/*
 	 * Unlike getOrigin, these two methods arranges and returns positions according to the Glist Engine.
-	 * These get methods works for soft objects.
+	 * These get methods works for soft objects too.
 	 */
 	// convert bullet3 positions to Glist Engine positions and return for circle objects.
 	glm::vec2 getCircle2dObjectPosition(gImageGameObject* imgObject);
-	// convert> a bullet3 positions to Glist Engine positions and return for box objects.
+	// convert a bullet3 positions to Glist Engine positions and return for box objects.
 	glm::vec2 getBox2dObjectPosition(gImageGameObject* imgObject);
-
-	btCollisionObjectArray& getCollisionObjectArray();
+	glm::vec3 get2dObjectRotation(gImageGameObject* imgObject);
 
 private:
+	enum worldType {
+		rigidWorld = 0,
+		softRigidWorld = 1
+	};
+
 	btDefaultCollisionConfiguration* collisionconfiguration;
 	btCollisionDispatcher* dispatcher;
 	btBroadphaseInterface* overlappingpaircache;
@@ -84,7 +97,11 @@ private:
 	btConstraintSolver* constraintsolver;
 	btBroadphaseInterface* broadphase;
 
+	btTransform getTransform(int imgObjectId);
 	btRigidBody* getRigidBody(gImageGameObject* imgObject);
+
+	// Call it in stepSimulation method to see the position and rotation of the objects.
+	void printObjectTransform();
 };
 
 #endif /* SRC_GIPBULLETPHYSICS_H_ */


### PR DESCRIPTION
- Initialize methods merged. -Added get set methods to dynamic world configuration variables.
- In stepSimulation, gameobject positions and rotations are now updating every cycle.
- gameobjectid removed due to not required anymore.
- gameobjects vector added instead of gameobjectid.
- getObjectRotation method added.
- The gameobjects vector is cleaned in the clean method now.
- printObjectTransform method added as private for testing gameobject transform.
- createSoftCircle2dObject doesn't use compound shape anymore.