### PR TITLE
gipBullet bugfix update for over 60fps games

### DIFF
--- a/src/gipBulletPhysics.cpp
+++ b/src/gipBulletPhysics.cpp
@@ -139,7 +139,7 @@ bool gipBulletPhysics::raycastHit(glm::vec3 from, glm::vec3 to, int masklayers, 
 // need to be called from game each update
 void gipBulletPhysics::runPhysicWorldStep(float deltatime) {
 	// Physics calculations doing here.
-	_dynamicsworld->stepSimulation(deltatime, 10);
+	_dynamicsworld->stepSimulation(deltatime, 0);
 	// update objects position
 	for (auto& object : this->_objects) {
 		// don't update if object is static rb.

--- a/src/gipBulletPhysics.h
+++ b/src/gipBulletPhysics.h
@@ -49,8 +49,8 @@ public:
 		LAYERNONMEMBER = -1, //Dont use this, this just for check
 		LAYER0 = 1 << 0,	//Dont collide layer
 		LAYER1 = 1 << 1,	//Default collide layer
-		LAYER2 = 1 << 2,
-		LAYER3 = 1 << 3,
+		LAYER2 = 1 << 2,	//Player bullet layer
+		LAYER3 = 1 << 3,	//player layer
 		LAYER4 = 1 << 4,
 		LAYER5 = 1 << 5,
 		LAYER6 = 1 << 6,


### PR DESCRIPTION
1)stepSimulation's substep count decreased to 0. Because of using substeps of 10, some bullets could not take the initial creation for. The issue got solved and without substep interpolation the game looks more smooth without any performance issues. Performance tested on a GTX4060 gaming pc.
Also comment lines added near to the used Collision Layers.